### PR TITLE
Use v2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Any warnings or errors will be annotated in the Pull Request.
 ## Usage
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 ```
 
 ### Parameter: check_filenames
@@ -16,7 +16,7 @@ If set, check file names for spelling mistakes as well.
 This parameter is optional; by default `codespell` will only check the file contents.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   check_filenames: true
 ```
@@ -28,7 +28,7 @@ If set, check hidden files (those starting with ".") for spelling mistakes as we
 This parameter is optional; by default `codespell` will not check hidden files.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   check_hidden: true
 ```
@@ -40,7 +40,7 @@ File with lines that should not be checked for spelling mistakes.
 This parameter is optional; by default `codespell` will check all lines.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   exclude_file: src/foo
 ```
@@ -52,7 +52,7 @@ Comma-separated list of files to skip (it accepts globs as well).
 This parameter is optional; by default `codespell` won't skip any files.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   skip: foo,bar
 ```
@@ -64,7 +64,7 @@ Comma-separated list of builtin dictionaries to use.
 This parameter is optional; by default `codespell` will use its default selection of built in dictionaries.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   builtin: clear,rare
 ```
@@ -77,7 +77,7 @@ Words are case sensitive based on how they are written in the dictionary file.
 This parameter is optional; by default `codespell` will check all words for typos.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   ignore_words_file: .codespellignore
 ```
@@ -90,7 +90,7 @@ Words are case sensitive based on how they are written in the dictionary file.
 This parameter is optional; by default `codespell` will check all words for typos.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   ignore_words_list: abandonned,ackward
 ```
@@ -104,7 +104,7 @@ If set to "*", all misspelling in URIs and emails will be ignored.
 This parameter is optional; by default `codespell` will check all URIs and emails for typos.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   uri_ignore_words_list: abandonned
 ```
@@ -117,7 +117,7 @@ This can be useful if your project has code you don't want to spell check for so
 This parameter is optional; by default `codespell` will run on your whole repository.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   path: src
 ```
@@ -131,7 +131,7 @@ All errors and warnings are annotated in Pull Requests, but it will act like eve
 This parameter is optional; setting this to any value will enable it.
 
 ```yml
-uses: codespell-project/actions-codespell@v1
+uses: codespell-project/actions-codespell@v2
 with:
   only_warn: 1
 ```


### PR DESCRIPTION
It looks like v2 is already released, so README should point it instead of v1.